### PR TITLE
Fixed warnings with latest VitaSDK

### DIFF
--- a/include/enet/vita.h
+++ b/include/enet/vita.h
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <psp2/kernel/clib.h>
 
 #define ENET_BUFFER_MAXIMUM 10
 

--- a/vita.c
+++ b/vita.c
@@ -22,7 +22,6 @@ int sceClibPrintf(const char *fmt, ...);
 #include "enet/enet.h"
 
 #define TCP_NODELAY SCE_NET_TCP_NODELAY
-#define INADDR_ANY SCE_NET_INADDR_ANY
 
 #define SOMAXCONN 128
 #define MSG_NOSIGNAL 0


### PR DESCRIPTION
Hi,
Today I was trying to build https://github.com/xyzz/vita-moonlight and when it tries to build enet (as git submodule) it shows some warnings:

```
[ 95%] Building C object CMakeFiles/moonlight.elf.dir/third_party/enet/protocol.c.obj
In file included from /home/gnuton/GITonio/vita-moonlight/third_party/enet/include/enet/enet.h:18:0,
                 from /home/gnuton/GITonio/vita-moonlight/third_party/enet/protocol.c:10:
/home/gnuton/GITonio/vita-moonlight/third_party/enet/protocol.c: In function 'enet_host_service':
/home/gnuton/GITonio/vita-moonlight/third_party/enet/include/enet/vita.h:53:16: warning: implicit declaration of function 'sceClibPrintf'; did you mean 'sniprintf'? [-Wimplicit-function-declaration]
 #define perror sceClibPrintf
                ^
/home/gnuton/GITonio/vita-moonlight/third_party/enet/protocol.c:1801:13: note: in expansion of macro 'perror'
             perror ("Error dispatching incoming packets");
             ^~~~~~
[ 96%] Building C object CMakeFiles/moonlight.elf.dir/third_party/enet/vita.c.obj
/home/gnuton/GITonio/vita-moonlight/third_party/enet/vita.c:25:0: warning: "INADDR_ANY" redefined
 #define INADDR_ANY SCE_NET_INADDR_ANY
 
In file included from /home/gnuton/GITonio/vita-moonlight/third_party/enet/vita.c:16:0:
/usr/local/vitasdk/arm-vita-eabi/include/netinet/in.h:59:0: note: this is the location of the previous definition
 #define INADDR_ANY  ((in_addr_t) 0x00000000)
 
[ 98%] Building C object CMakeFiles/moonlight.elf.dir/third_party/inih/ini.c.obj
[100%] Linking C executable moonlight.elf
```
This patch should solve those warnings.

Thanks,
Antonio