### PR TITLE
Silence GCC 6.2.0 warning

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -1386,8 +1386,8 @@ enet_protocol_check_outgoing_commands (ENetHost * host, ENetPeer * peer)
     ENetBuffer * buffer = & host -> buffers [host -> bufferCount];
     ENetOutgoingCommand * outgoingCommand;
     ENetListIterator currentCommand;
-    ENetChannel *channel;
-    enet_uint16 reliableWindow;
+    ENetChannel *channel = NULL;
+    enet_uint16 reliableWindow = 0;
     size_t commandSize;
     int windowExceeded = 0, windowWrap = 0, canPing = 1;
 


### PR DESCRIPTION
Initialized 2 variables to silence GCC 6.2.0 warning.

```
[build] [ 24%] Building C object core/moonlight-common-c/CMakeFiles/moonlight-common-c.dir/enet/protocol.c.o
[build] /home/mariotaku/Projects/moonlight-tv/core/moonlight-common-c/enet/protocol.c: In function ‘enet_protocol_check_outgoing_commands’:
[build] /home/mariotaku/Projects/moonlight-tv/core/moonlight-common-c/enet/protocol.c:1390:17: error: ‘reliableWindow’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
[build]      enet_uint16 reliableWindow;
[build]                  ^~~~~~~~~~~~~~
[build] /home/mariotaku/Projects/moonlight-tv/core/moonlight-common-c/enet/protocol.c:1459:45: error: ‘channel’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
[build]               channel -> usedReliableWindows |= 1 << reliableWindow;
[build]                                              ^~
[build] cc1: all warnings being treated as errors
```