### PR TITLE
Add CMake option to disable installation of headers and libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.12...3.20)
 
 project(enet)
 
+option(ENET_NO_INSTALL "Disable installation of headers and libraries" OFF)
+
 # The "configure" step.
 include(CheckFunctionExists)
 include(CheckStructHasMember)
@@ -108,10 +110,12 @@ if (MINGW)
     target_link_libraries(enet winmm ws2_32)
 endif()
 
-install(TARGETS enet
-    RUNTIME DESTINATION bin
-    ARCHIVE DESTINATION lib/static
-    LIBRARY DESTINATION lib)
+if(NOT ENET_NO_INSTALL)
+    install(TARGETS enet
+        RUNTIME DESTINATION bin
+        ARCHIVE DESTINATION lib/static
+        LIBRARY DESTINATION lib)
 
-install(DIRECTORY include/
-        DESTINATION include)
+    install(DIRECTORY include/
+            DESTINATION include)
+endif()


### PR DESCRIPTION
This PR is intended to fix LizardByte/Sunshine#1591. Basically Sunshine uses CMake's `add_subdirectory` to add enet library to the project. Unfortunately this causes enet headers and static library to be installed into Sunshine prefix. All Debian, Ubuntu, Fedora, Arch (and probably other) [nightly builds](https://github.com/LizardByte/Sunshine/releases/tag/nightly-dev) contain the following unwanted files:
* `/usr/include/enet/*.h`
* `/usr/lib/static/libenet.a`

The PR adds new CMake option named `ENET_NO_INSTALL` to disable installation of any enet files. By default installation is enabled. If changes look good to you, I'll create another PR in Sunshine repo which will use `ENET_NO_INSTALL` to get rid of enet headers/libs.

In fact, Sunshine already does [something similar](https://github.com/LizardByte/Sunshine/blob/nightly/cmake/dependencies/common.cmake#L15) for miniupnpc library. It uses `UPNPC_NO_INSTALL` option to disable installation of its headers/libs:
```
set(UPNPC_NO_INSTALL ON CACHE BOOL "Don't install any libraries build for miniupnpc")
```