### PR TITLE
Implement support for userbuffers on Wii U

### DIFF
--- a/include/enet/enet.h
+++ b/include/enet/enet.h
@@ -200,7 +200,11 @@ typedef enum _ENetPeerState
 
 enum
 {
-#ifdef __3DS__
+#if defined(__WIIU__)
+   ENET_HOST_RECEIVE_BUFFER_SIZE          = 256 * 1024,
+   // Send buffer size is limited since it cannot use userbuffers
+   ENET_HOST_SEND_BUFFER_SIZE             = 0x10000 - 1,
+#elif defined(__3DS__)
    ENET_HOST_RECEIVE_BUFFER_SIZE          = 0x20000,
    ENET_HOST_SEND_BUFFER_SIZE             = 0x20000,
 #else

--- a/unix.c
+++ b/unix.c
@@ -393,6 +393,14 @@ enet_socket_create (int af, ENetSocketType type)
     }
 #endif
 
+#ifdef __WIIU__
+    {
+        // Enable usage of userbuffers on Wii U
+        int on = 1;
+        setsockopt(sock, SOL_SOCKET, SO_RUSRBUF, (char *)&on, sizeof(on));
+    }
+#endif
+
     return sock;
 }
 


### PR DESCRIPTION
The Wii U socket implementation has limited memory available. To support larger receive buffers, application memory needs to be provided. To make sockets use this user memory the `SO_RUSRBUF` option needs to be set on the socket.