### PR TITLE
Add Support for Haiku OS: Conditional Compilation for socklen_t

### DIFF
--- a/unix.c
+++ b/unix.c
@@ -164,7 +164,7 @@
 #include <poll.h>
 #endif
 
-#if !defined(HAS_SOCKLEN_T) && !defined(__socklen_t_defined)
+#if !defined(HAS_SOCKLEN_T) && !defined(__socklen_t_defined) && !defined(__HAIKU__)
 typedef int socklen_t;
 #endif
 


### PR DESCRIPTION
This change allows the project to compile successfully on Haiku OS without encountering issues related to the definition of socklen_t.