### PR TITLE
Removes unnecessary definitions for PS Vita and ensures unavailabilit…

### DIFF
--- a/unix.c
+++ b/unix.c
@@ -57,23 +57,15 @@
 #define HAS_GETNAMEINFO 1
 #endif
 #elif defined(__vita__)
-#ifdef HAS_POLL
-#undef HAS_POLL
-#endif
-#ifdef HAS_FCNTL
-#undef HAS_FCNTL
-#endif
-#ifdef HAS_IOCTL
-#undef HAS_IOCTL
+// PS Vita: No support for ancillary data or advanced message control
+#ifndef NO_MSGAPI
+#define NO_MSGAPI 1
 #endif
 #ifndef HAS_INET_PTON
 #define HAS_INET_PTON 1
 #endif
 #ifndef HAS_INET_NTOP
 #define HAS_INET_NTOP 1
-#endif
-#ifdef HAS_MSGHDR_FLAGS
-#undef HAS_MSGHDR_FLAGS
 #endif
 #ifndef HAS_SOCKLEN_T
 #define HAS_SOCKLEN_T 1
@@ -906,4 +898,3 @@ enet_socket_wait (ENetSocket socket, enet_uint32 * condition, enet_uint32 timeou
 }
 
 #endif
-


### PR DESCRIPTION
This pull request updates the `unix.c` file to adjust platform-specific configurations for the PS Vita. It removes unsupported features and adds a new macro to indicate the lack of support for advanced message control.

Platform-specific configuration updates:

* Removed definitions for unsupported features on PS Vita, such as `HAS_POLL`, `HAS_FCNTL`, `HAS_IOCTL`, and `HAS_MSGHDR_FLAGS`. These features are no longer applicable to the platform.
* Added the `NO_MSGAPI` macro to indicate that PS Vita does not support ancillary data or advanced message control. This provides clarity and prevents misuse of unsupported APIs.

No functional changes were made to the `enet_socket_wait` function; the empty line removal appears to be a minor formatting adjustment.