### PR TITLE
Change Windows header includes to lowercase for easier cross-compilation

### DIFF
--- a/include/enet/win32.h
+++ b/include/enet/win32.h
@@ -18,7 +18,7 @@
 
 #include <stdlib.h>
 #include <winsock2.h>
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 
 typedef SOCKET ENetSocket;
 

--- a/win32.c
+++ b/win32.c
@@ -7,7 +7,7 @@
 #define ENET_BUILDING_LIB 1
 #include "enet/enet.h"
 #include <windows.h>
-#include <Mswsock.h>
+#include <mswsock.h>
 #ifndef HAS_QOS_FLOWID
 typedef UINT32 QOS_FLOWID;
 #endif
@@ -23,7 +23,7 @@ static enet_uint32 timeBase = 0;
 
 #if !(defined(WINAPI_FAMILY) && WINAPI_FAMILY == WINAPI_FAMILY_APP)
 # define HAS_QWAVE
-# include <VersionHelpers.h>
+# include <versionhelpers.h>
 #else
 # define IsWindows10OrGreater() TRUE
 #endif


### PR DESCRIPTION
This PR changes Windows header includes to their lowercase equivalents.

Windows filesystems are case-insensitive, so this makes no difference on direct Windows builds. However, Linux filesystems are case-sensitive. Using lowercase headers improves compatibility with MinGW-w64 and other cross-compilation environments.